### PR TITLE
Add social deduction framework template

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,6 +241,7 @@ conda activate ai_scientist
 # Run the paper generation.
 python launch_scientist.py --model "gpt-4o-2024-05-13" --experiment nanoGPT_lite --num-ideas 2
 python launch_scientist.py --model "claude-3-5-sonnet-20241022" --experiment nanoGPT_lite --num-ideas 2
+python launch_scientist.py --model "gpt-4o-2024-05-13" --experiment social_deduction_framework --num-ideas 2
 ```
 
 If you have more than one GPU, use the `--parallel` option to parallelize ideas across multiple GPUs.
@@ -305,6 +306,7 @@ We welcome community contributions in the form of new templates. While these are
 - Earthquake Prediction (`earthquake-prediction`) - [PR #167](https://github.com/SakanaAI/AI-Scientist/pull/167)
 - Tensorial Radiance Fields (`tensorf`) - [PR #175](https://github.com/SakanaAI/AI-Scientist/pull/175)
 - Large Language Model Steering / Probes (`probes`) - [PR #215](https://github.com/SakanaAI/AI-Scientist/pull/215)
+- Social Deduction Framework (`social_deduction_framework`) - [PR #XXX](https://github.com/SakanaAI/AI-Scientist/pull/XXX)
 
 *This section is reserved for community contributions. Please submit a pull request to add your template to the list! Please describe the template in the PR description, and also show examples of the generated papers.*
 

--- a/templates/social_deduction_framework/base_code/simulate.py
+++ b/templates/social_deduction_framework/base_code/simulate.py
@@ -1,0 +1,37 @@
+import random
+
+
+def simulate_game(rules, num_games=10):
+    """Run a very simple social deduction game simulation.
+
+    Parameters
+    ----------
+    rules : dict
+        Dictionary containing game parameters like number of players and imposters.
+    num_games : int
+        Number of simulations to run.
+
+    Returns
+    -------
+    dict
+        Dictionary with average win rate and average number of turns.
+    """
+    num_players = int(rules.get("num_players", 4))
+    imposters = int(rules.get("imposters", 1))
+    win_count = 0
+    total_turns = 0
+    for _ in range(num_games):
+        turns = random.randint(5, 15)
+        total_turns += turns
+        # Imposters win with probability proportional to their number
+        if random.random() < imposters / float(num_players):
+            win_count += 1
+    return {
+        "win_rate": win_count / float(num_games),
+        "avg_turns": total_turns / float(num_games),
+    }
+
+
+if __name__ == "__main__":
+    example_rules = {"num_players": 5, "imposters": 1}
+    print(simulate_game(example_rules))

--- a/templates/social_deduction_framework/experiment.py
+++ b/templates/social_deduction_framework/experiment.py
@@ -1,0 +1,28 @@
+import argparse
+import json
+import os
+
+from base_code.simulate import simulate_game
+
+parser = argparse.ArgumentParser(description="Evaluate social deduction game rules")
+parser.add_argument("--out_dir", type=str, default="run_0", help="Output directory")
+parser.add_argument("--rules", type=str, default="rules.json", help="JSON file containing rule definition")
+
+
+def main():
+    args = parser.parse_args()
+    os.makedirs(args.out_dir, exist_ok=True)
+    if os.path.exists(args.rules):
+        with open(args.rules, "r") as f:
+            rules = json.load(f)
+    else:
+        # Default rule set
+        rules = {"num_players": 4, "imposters": 1}
+
+    metrics = simulate_game(rules)
+    with open(os.path.join(args.out_dir, "final_info.json"), "w") as f:
+        json.dump({"GameMetrics": metrics}, f)
+
+
+if __name__ == "__main__":
+    main()

--- a/templates/social_deduction_framework/ideas.json
+++ b/templates/social_deduction_framework/ideas.json
@@ -1,0 +1,11 @@
+[
+    {
+        "Name": "hidden_imposter",
+        "Title": "Hidden Imposter Variant",
+        "Experiment": "Introduce one secret imposter who wins if not revealed after five rounds.",
+        "Interestingness": 6,
+        "Feasibility": 8,
+        "Novelty": 5,
+        "novel": true
+    }
+]

--- a/templates/social_deduction_framework/judge_manual.py
+++ b/templates/social_deduction_framework/judge_manual.py
@@ -1,0 +1,30 @@
+import argparse
+import json
+
+try:
+    import textstat
+except ImportError:  # pragma: no cover - optional dependency
+    textstat = None
+
+
+def readability(text: str) -> float:
+    if textstat is not None:
+        # Flesch Reading Ease scaled to 0-1
+        return max(0.0, min(1.0, textstat.flesch_reading_ease(text) / 100.0))
+    # Fallback: rough heuristic based on length
+    return max(0.0, 1.0 - len(text) / 1000.0)
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Score manual for clarity and reproducibility")
+    parser.add_argument("manual", type=str, help="Path to generated manual")
+    args = parser.parse_args()
+    with open(args.manual, "r") as f:
+        text = f.read()
+    score = readability(text)
+    result = {"clarity": score, "reproducibility": score}
+    print(json.dumps(result))
+
+
+if __name__ == "__main__":
+    main()

--- a/templates/social_deduction_framework/make_manual.py
+++ b/templates/social_deduction_framework/make_manual.py
@@ -1,0 +1,23 @@
+import argparse
+import json
+
+
+def make_markdown(rules, out_file):
+    with open(out_file, "w") as f:
+        f.write("# Game Manual\n\n")
+        for key, value in rules.items():
+            f.write(f"- **{key}**: {value}\n")
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Generate Markdown manual from rules")
+    parser.add_argument("--rules", type=str, default="rules.json")
+    parser.add_argument("--out", type=str, default="manual.md")
+    args = parser.parse_args()
+    with open(args.rules, "r") as f:
+        rules = json.load(f)
+    make_markdown(rules, args.out)
+
+
+if __name__ == "__main__":
+    main()

--- a/templates/social_deduction_framework/prompt.json
+++ b/templates/social_deduction_framework/prompt.json
@@ -1,0 +1,4 @@
+{
+    "system": "You are an AI designer creating new social deduction board games.",
+    "task_description": "Evaluate proposed rule changes using the simulation framework and produce manuals and analysis."
+}

--- a/templates/social_deduction_framework/rules.json
+++ b/templates/social_deduction_framework/rules.json
@@ -1,0 +1,4 @@
+{
+    "num_players": 5,
+    "imposters": 1
+}


### PR DESCRIPTION
## Summary
- add a new `social_deduction_framework` template with simulation code, manual helpers and example ideas
- show example command for this template in README
- list the template in community contributions

## Testing
- `python -m py_compile templates/social_deduction_framework/*.py templates/social_deduction_framework/base_code/*.py`
