### PR TITLE
Extend docker option for plotting

### DIFF
--- a/README.md
+++ b/README.md
@@ -388,6 +388,13 @@ docker run -it -e OPENAI_API_KEY=$OPENAI_API_KEY \
   <AI_SCIENTIST_IMAGE>
 ```
 
+The experiment runner supports executing `experiment.py` (and subsequent
+`plot.py`) inside a container using `docker run` with restricted resources.
+Pass `--docker` when launching `launch_scientist.py` to enable this wrapper. You
+may also set a custom image via `--docker-image` (defaults to
+`ai-scientist:latest`). The container runs with one CPU, 2GB of memory and no
+network access to mitigate malicious code.
+
 ## Star History
 
 [![Star History Chart](https://api.star-history.com/svg?repos=SakanaAI/AI-Scientist&type=Date)](https://star-history.com/#SakanaAI/AI-Scientist&Date)


### PR DESCRIPTION
## Summary
- allow optional Docker wrapper for plotting steps as well as experiments
- check for Docker availability before using `--docker`
- document that `plot.py` will also run in the container

## Testing
- `python -m py_compile ai_scientist/perform_experiments.py launch_scientist.py`
